### PR TITLE
Update syntax to use liquid-style attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This jekyll liquid tag, is a plugin that will let you easily include svg [octico
 3. Use this tag in your jekyll templates
 
     ```
-    {% octicon :symbol => "alert", :size => "large", :class => "right left", :'aria-label' => "hi" %}
+    {% octicon alert size:large class:"right left" aria-label:hi %}
     ```
 
 ## Documentation

--- a/lib/jekyll-octicons.rb
+++ b/lib/jekyll-octicons.rb
@@ -4,10 +4,18 @@ require 'liquid'
 
 module Jekyll
   class Octicons < Liquid::Tag
+    # Syntax for the octicon symbol
+    Syntax = /\A(#{Liquid::VariableSignature}+)/
 
-    def initialize(tag_name, options, tokens)
+    # Copied from Liquid::TagAttributes to allow dashes in tag names:
+    #
+    #   {% octicon alert area-label:"Hello World!" %}
+    #
+    TagAttributes = /([\w-]+)\s*\:\s*(#{Liquid::QuotedFragment})/o
+
+    def initialize(tag_name, markup, options)
       super
-      @options = string_to_hash(options)
+      @options = string_to_hash(markup)
     end
 
     def render(context)
@@ -18,14 +26,18 @@ module Jekyll
     private
 
     # Create a ruby hash from a string passed by the jekyll tag
-    def string_to_hash(options)
-      Hash[options.split(",").map do |s|
-        s.gsub(/[:\"']/,"").split("=>").map.with_index do |e, i|
-          e.strip!
-          e = e.to_sym if i == 0
-          e
+    def string_to_hash(markup)
+      options = {}
+
+      if match = markup.match(Syntax)
+        options[:symbol] = match[1]
+
+        markup.scan(TagAttributes) do |key, value|
+          options[key.to_sym] = value.gsub(/\A"|"\z/, '')
         end
-      end]
+      end
+
+      options
     end
   end
 end

--- a/test/octicon_tag_test.rb
+++ b/test/octicon_tag_test.rb
@@ -3,18 +3,20 @@ require_relative "./helper"
 describe Jekyll::Octicons do
   describe "parsing" do
     it "parses the tag options" do
-      template = parse('{% octicon :symbol => "logo-github", :size => "large" %}')
+      template = parse('{% octicon logo-github size:large class:"left right" aria-label:hi %}')
       node = template.root.nodelist[0]
       assert node
       assert node.instance_of?(Jekyll::Octicons)
       assert_equal "logo-github", node.options[:symbol]
       assert_equal "large", node.options[:size]
+      assert_equal "left right", node.options[:class]
+      assert_equal "hi", node.options[:"aria-label"]
     end
   end
 
   describe "rendering" do
     it "renders the svg" do
-      output = render('{% octicon :symbol => "logo-github", :size => "large" %}')
+      output = render('{% octicon logo-github size:large %}')
       assert_match /<svg.*octicon-logo-github.*height="32"/, output
     end
 


### PR DESCRIPTION
Before:

     {% octicon :symbol => "alert", :size => "large", :class => "right left", :'aria-label' => "hi" %}

After:

    {% octicon alert size:large class:"right left" aria-label:hi %}