### PR TITLE
Adding interpolation of variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# HEAD
+
+- Added: Interpoaltion of variables in liquid tag
+
+# 1.0.0
+
+- Added: First release, jekyll tag for octicons

--- a/lib/jekyll-octicons.rb
+++ b/lib/jekyll-octicons.rb
@@ -1,4 +1,5 @@
 require 'octicons'
+require 'jekyll-octicons/version'
 require 'liquid'
 require 'jekyll/liquid_extensions'
 

--- a/test/octicon_tag_test.rb
+++ b/test/octicon_tag_test.rb
@@ -4,13 +4,18 @@ describe Jekyll::Octicons do
   describe "parsing" do
     it "parses the tag options" do
       template = parse('{% octicon logo-github size:large class:"left right" aria-label:hi %}')
-      node = template.root.nodelist[0]
+      node = template.root.nodelist.last
       assert node
       assert node.instance_of?(Jekyll::Octicons)
       assert_equal "logo-github", node.options[:symbol]
       assert_equal "large", node.options[:size]
       assert_equal "left right", node.options[:class]
       assert_equal "hi", node.options[:"aria-label"]
+    end
+
+    it "parses interpoaltion of variables" do
+      template = render('{% assign symbol = "logo-github" %}{% octicon {{ symbol }} %}')
+      assert_match /<svg.*octicon-logo-github.*/, template
     end
   end
 


### PR DESCRIPTION
This adds the ability to interpolate liquid variables into the tag. ie

```
{% octicon {{ icon }} %}
```