### PR TITLE
Updating plugin to use octicons@2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 # 1.1.0
 
-- Added: Interpoaltion of variables in liquid tag
+- Added: Interpolation of variables in liquid tag
 - Updating octicons gem version to 1.1.0
 
 # 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 2.0.0
 
 - Updating octicons gem version to 2.0.0
-- Drops support for `size:"large"` [#8](option https://github.com/primer/octicons_gem/pull/8)
+- Drops support for `size:"large"` [#8](https://github.com/primer/octicons_gem/pull/8)
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HEAD
 
+# 2.0.0
+
+- Updating octicons gem version to 2.0.0
+- Drops support for `size:"large"` [#8](option https://github.com/primer/octicons_gem/pull/8)
+
 # 1.1.0
 
 - Added: Interpoaltion of variables in liquid tag

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'octicons'
+gem 'octicons', '~> 2.0'
 
 group :development, :test do
   gem 'rake'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This jekyll liquid tag, is a plugin that will let you easily include svg [octico
 3. Use this tag in your jekyll templates
 
     ```
-    {% octicon alert size:large class:"right left" aria-label:hi %}
+    {% octicon alert height:32 class:"right left" aria-label:hi %}
     ```
 
 The minimum CSS you'll need in your jekyll site is in the [octicons][octicons] repository. You can also npm install that package and include `build/octicons.css` in your styles.

--- a/jekyll-octicons.gemspec
+++ b/jekyll-octicons.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'jekyll', '~> 3.1'
-  s.add_dependency 'octicons', '~> 1.0'
+  s.add_dependency 'octicons', '~> 2.0'
 end

--- a/lib/jekyll-octicons.rb
+++ b/lib/jekyll-octicons.rb
@@ -22,26 +22,42 @@ module Jekyll
     def initialize(tag_name, markup, options)
       super
       @markup = markup
-      @options = string_to_hash(markup)
+      # If there's interpoaltion going on, we need to do this in render
+      prepare(markup) unless match = markup.match(Variable)
     end
 
     def render(context)
-      @markup.scan Variable do |variable|
-        @options = string_to_hash(@markup.gsub(Variable, lookup_variable(context, variable.first)))
-      end
-      return nil if @options[:symbol].nil?
-      ::Octicons::Octicon.new(@options).to_svg
+      prepare(interpolate(@markup, context)) if match = @markup.match(Variable)
+
+      return nil if @symbol.nil?
+      ::Octicons::Octicon.new(@symbol, @options).to_svg
     end
 
     private
+
+    def interpolate(markup, context)
+      markup.scan Variable do |variable|
+        markup = markup.gsub(Variable, lookup_variable(context, variable.first))
+      end
+      markup
+    end
+
+    def prepare(markup)
+      @symbol = symbol(markup)
+      @options = string_to_hash(markup)
+    end
+
+    def symbol(markup)
+      if match = markup.match(Syntax)
+        match[1]
+      end
+    end
 
     # Create a ruby hash from a string passed by the jekyll tag
     def string_to_hash(markup)
       options = {}
 
       if match = markup.match(Syntax)
-        options[:symbol] = match[1]
-
         markup.scan(TagAttributes) do |key, value|
           options[key.to_sym] = value.gsub(/\A"|"\z/, '')
         end

--- a/lib/jekyll-octicons/version.rb
+++ b/lib/jekyll-octicons/version.rb
@@ -3,6 +3,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Octicons < Liquid::Tag
-    VERSION = '1.1.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end

--- a/test/octicon_tag_test.rb
+++ b/test/octicon_tag_test.rb
@@ -3,12 +3,11 @@ require_relative "./helper"
 describe Jekyll::Octicons do
   describe "parsing" do
     it "parses the tag options" do
-      template = parse('{% octicon logo-github size:large class:"left right" aria-label:hi %}')
+      template = parse('{% octicon logo-github height:32 class:"left right" aria-label:hi %}')
       node = template.root.nodelist.last
       assert node
       assert node.instance_of?(Jekyll::Octicons)
-      assert_equal "logo-github", node.options[:symbol]
-      assert_equal "large", node.options[:size]
+      assert_equal "32", node.options[:height]
       assert_equal "left right", node.options[:class]
       assert_equal "hi", node.options[:"aria-label"]
     end
@@ -21,8 +20,9 @@ describe Jekyll::Octicons do
 
   describe "rendering" do
     it "renders the svg" do
-      output = render('{% octicon logo-github size:large %}')
-      assert_match /<svg.*octicon-logo-github.*height="32"/, output
+      output = render('{% octicon logo-github height:32 %}')
+      assert_match /<svg.*octicon-logo-github.*/, output
+      assert_match /<svg.*width="90".*/, output
     end
 
     it "renders nothing without a symbol" do


### PR DESCRIPTION
There's a bunch of breaking changes in [octicons@2.0.0](https://github.com/primer/octicons_gem/blob/master/CHANGELOG.md#200)

The one that effects jekyll-octicons the most is [deprecating the use of `:size`](https://github.com/primer/octicons_gem/pull/8)
